### PR TITLE
v1.1.0: Auto-Tasks; Automatically Apply Formatting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,22 @@
+name: build
+
+on: [push]
+
+jobs:
+  build:
+    name: Build with gradle on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+
+    - name: Build with Gradle
+      run: ./gradlew build

--- a/.github/workflows/publish-plugin.yml
+++ b/.github/workflows/publish-plugin.yml
@@ -1,0 +1,24 @@
+name: publish plugin
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    name: Build with gradle
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - name: Publish to Gradle Plugins
+        env:
+          GRADLE_PUBLISH_KEY: XOqE2tDUKTWskRYEwjTWF1JORK3pejYi
+          GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
+        run: ./gradlew publishPlugins -Pgradle.publish.key=$GRADLE_PUBLISH_KEY -Pgradle.publish.secret=$GRADLE_PUBLISH_SECRET

--- a/README.md
+++ b/README.md
@@ -13,15 +13,19 @@ Simply include this plugin in your `build.gradle` by following [this guide](http
     - `.gradle`
     - `.md`
     - `.gitignore`
+    - `.yml`/`.yaml`
 
 ## Usage
-You'd use this in the same way that you'd use Spotless directly, just without the need to add your own configuration.
+So after setting up, you can approach usage in a few different ways:
 
-So after setting up, you can run `./gradlew build` and will be faced with error messages (preventing build) unless your code passes the formatting requirements.
+- You can take the same steps you'd normally take or encounter with Spotless:
+    1. Run `./gradlew build` and will be faced with error messages (preventing build) if your code passes does not pass the formatting requirements.
+    1. If you got an error, run `./gradlew spotlessApply build` to format your project files automatically and retry the build.
+- Or you can add a shortcut to make things a *little* more automated:
+    1. Set the environment variable `AUTO_SPOTLESS_ENV` to `dev` if you don't like manually writing `spotlessApply`. This will cause the `build` task to trigger `spotlessApply` for you automatically any time it is run.
+    1. Be sure to check for formatting changes. A reminder for this will appear as well as the output of `git status -s -uno` (if you're in a git repository) to show what's changed in your tracked files (hopefully this helps to speed things up for you).
 
-Run `./gradlew spotlessApply` to format your project files automatically and then your build should work again.
-
-*TODO: I have plans to automatically trigger the `spotlessApply` task if a certain environment variable is set, but that will be added for the `v1.1.0` release.*
+## Etc
 
 ### Why does this exist?
 As with many things, I was trying to find/build a centralized package to enforce formatting styles on my personal projects without having to copy/paste over all the configs each time.

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 project.description = 'Preconfigured spotless configuration and gradle tasks for use in other projects'
 project.group = 'com.jonathanrobertson.spotless'
-project.version = '1.0.0'
+project.version = '1.1.0'
 
 project.ext.name = 'auto-spotless-plugin'
 project.ext.pluginId = 'com.jonathanrobertson.spotless'

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ spotless {
         eclipse().configFile('src/main/resources/spotless.eclipseformat.xml')
     }
     format 'misc', {
-        target '**/*.md', '**/*.gradle', '**/.gitignore'
+        target '**/*.md', '**/*.gradle', '**/.gitignore', '**/*.yml', '**/*.yaml'
         trimTrailingWhitespace()
         endWithNewline()
         replaceRegex 'too many blank lines', '^\\n\\n+', '\n'

--- a/src/main/java/com/jonathanrobertson/spotless/AutoFormatWarningTask.java
+++ b/src/main/java/com/jonathanrobertson/spotless/AutoFormatWarningTask.java
@@ -1,0 +1,12 @@
+package com.jonathanrobertson.spotless;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.tasks.TaskAction;
+
+public class AutoFormatWarningTask extends DefaultTask {
+
+	@TaskAction
+	public void printWarning() {
+		System.out.println("WARNING: spotlessApply was run automatically; check for changes before pushing to remote");
+	}
+}

--- a/src/main/java/com/jonathanrobertson/spotless/AutoSpotlessPlugin.java
+++ b/src/main/java/com/jonathanrobertson/spotless/AutoSpotlessPlugin.java
@@ -32,7 +32,7 @@ public class AutoSpotlessPlugin implements Plugin<Project> {
 		});
 
 		spotlessExtension.format("misc", format -> {
-			format.target("**/*.md", "**/*.gradle", "**/.gitignore");
+			format.target("**/*.md", "**/*.gradle", "**/.gitignore", "**/*.yml", "**/*.yaml");
 			format.trimTrailingWhitespace();
 			format.endWithNewline();
 

--- a/src/main/java/com/jonathanrobertson/spotless/GitStatusTask.java
+++ b/src/main/java/com/jonathanrobertson/spotless/GitStatusTask.java
@@ -1,0 +1,26 @@
+package com.jonathanrobertson.spotless;
+
+import java.io.*;
+import java.util.StringJoiner;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.UncheckedIOException;
+import org.gradle.api.tasks.TaskAction;
+
+public class GitStatusTask extends DefaultTask {
+
+	@TaskAction
+	public void gitStatus() {
+		try {
+			Process p = new ProcessBuilder("git", "status", "-s", "-uno").start();
+			try (InputStream is = p.getInputStream(); InputStreamReader r = new InputStreamReader(is); BufferedReader b = new BufferedReader(r)) {
+				StringJoiner joiner = new StringJoiner(System.getProperty("line.separator"));
+				b.lines().iterator().forEachRemaining(joiner::add);
+				p.waitFor();
+				System.out.println(joiner.toString());
+			}
+		} catch (InterruptedException | IOException e) {
+			throw new UncheckedIOException("unable to write git status", e);
+		}
+	}
+}

--- a/src/main/resources/spotless.eclipseformat.xml
+++ b/src/main/resources/spotless.eclipseformat.xml
@@ -341,7 +341,7 @@
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_field_declarations" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.wrap_before_string_concatenation" value="true"/>
 <setting id="org.eclipse.jdt.core.formatter.blank_lines_between_import_groups" value="1"/>
-<setting id="org.eclipse.jdt.core.formatter.lineSplit" value="120"/>
+<setting id="org.eclipse.jdt.core.formatter.lineSplit" value="9999"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_annotation" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_switch" value="insert"/>
 </profile>

--- a/src/test/java/com/jonathanrobertson/spotless/AutoSpotlessPluginTest.java
+++ b/src/test/java/com/jonathanrobertson/spotless/AutoSpotlessPluginTest.java
@@ -2,13 +2,26 @@ package com.jonathanrobertson.spotless;
 
 import static org.junit.Assert.*;
 
+import java.nio.file.Paths;
+import java.util.Arrays;
+
+import org.junit.Assert;
 import org.junit.Test;
 
 public class AutoSpotlessPluginTest {
 
 	@Test
 	public void getAbsolutePathFromEmbeddedFile() {
-		AutoSpotlessPlugin.getAbsolutePathFromEmbeddedFile("spotless.importorder");
-		AutoSpotlessPlugin.getAbsolutePathFromEmbeddedFile("spotless.eclipseformat.xml");
+		final String tempDir = System.getProperty("java.io.tmpdir");
+		Arrays.asList("spotless.importorder", "spotless.eclipseformat.xml").forEach(filename -> {
+			String expected = Paths.get(tempDir, filename).toString();
+			String actual = AutoSpotlessPlugin.getAbsolutePathFromEmbeddedFile(filename).getAbsolutePath();
+			Assert.assertEquals(expected, actual);
+		});
+	}
+
+	@Test
+	public void gitIsPresent() {
+		AutoSpotlessPlugin.gitIsPresent(); // just confirm an unexpected exception doesn't appear
 	}
 }


### PR DESCRIPTION
- Add GitHub Action to auto-build in pipeline
- Add GitHub Action to publish on release
- Update Eclipse Java format to wrap lines at 9999 character length (I don't like line wrapping)
- Add `.yml`/`.yaml` files to formatting rules
- Add convenience mode where `spotlessApply` task is automatically fired on build
  - set environment variable: `AUTO_SPOTLESS_ENV=dev`